### PR TITLE
Adding Update URI to prevent conflicts with .org

### DIFF
--- a/expiring-posts.php
+++ b/expiring-posts.php
@@ -4,6 +4,7 @@
  *
  * Plugin Name: Expiring Posts
  * Plugin URI: https://github.com/alleyinteractive/expiring-posts
+ * Update URI: https://github.com/alleyinteractive/expiring-posts
  * Description: Automatic expiration of posts.
  * Version: 0.2.0
  * Author: Alley


### PR DESCRIPTION
Add a plugin header to prevent updates from conflicting with https://wordpress.org/plugins/expiring-posts/